### PR TITLE
Hot-fix: Messed up routes when release on GitHub Page

### DIFF
--- a/lib/widgets/app_scaffold.dart
+++ b/lib/widgets/app_scaffold.dart
@@ -17,35 +17,24 @@ class AppScaffold extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PopScope(
-      onPopInvokedWithResult: (didPop, result) {
-        if (didPop) {
-          if (onBackButtonPressed != null) {
-            onBackButtonPressed?.call(context);
-          } else {
-            NavigationUtils.goBack(context);
-          }
-        }
-      },
-      child: Scaffold(
-        appBar: AppBar(
-          title: Text(
-            title,
-            style: Theme.of(context).textTheme.displaySmall!.copyWith(
-                  color: Colors.black,
-                ),
-          ),
-          leading: (showBackButton ?? false)
-              ? IconButton(
-                  icon: const Icon(Icons.arrow_back),
-                  onPressed: () => onBackButtonPressed != null
-                      ? onBackButtonPressed?.call(context)
-                      : Navigator.of(context).pop(),
-                )
-              : null,
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          title,
+          style: Theme.of(context).textTheme.displaySmall!.copyWith(
+                color: Colors.black,
+              ),
         ),
-        body: body,
+        leading: (showBackButton ?? false)
+            ? IconButton(
+                icon: const Icon(Icons.arrow_back),
+                onPressed: () => onBackButtonPressed != null
+                    ? onBackButtonPressed?.call(context)
+                    : Navigator.of(context).pop(),
+              )
+            : null,
       ),
+      body: body,
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -574,10 +574,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: "2ddb88e9ad56ae15ee144ed10e33886777eb5ca2509a914850a5faa7b52ff459"
+      sha256: "8660b74171fafae4aa8202100fa2e55349e078281dadc73a241eb8e758534d9d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.7"
+    version: "14.6.1"
   google_fonts:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,7 +49,7 @@ dependencies:
   phone_form_field: ^9.2.5
   dropdown_button2: ^2.3.9
   flutter_adaptive_scaffold: ^0.2.4
-  go_router: ^14.2.7
+  go_router: ^14.6.1
   universal_html: ^2.2.4
   get_it: ^7.7.0
   flutter_map: ^7.0.2


### PR DESCRIPTION
## Root cause
- Currently wrapping `Scaffold` inside `PopScope` messed the routes up when pop back.
- `GoRouter` version `14.2.7` have problem when pop back.

## Solution
- Update GoRouter to `latest` version
- Remove `PopScrope` from `AppScaffold`
