### PR TITLE
Bump version to v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2 - 21/12/2024
+## Added
+- Listen when scan ticket error
+
 ## v0.1.1 - 18/12/2024
 ## Added
 - Secure ticket's QR code


### PR DESCRIPTION
## Summary
This pull request introduces a new feature to handle errors when scanning tickets. The changes include updates to the `CHANGELOG.md` file and modifications to the `TicketDetailsController` class in `ticket_details.dart`.

New feature for error handling:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R4): Added a new entry for version 0.1.2, noting the addition of listening for scan ticket errors.
* `lib/pages/ticket_details/ticket_details.dart`: 
  * Added `_listenBroadcastError` method to listen for broadcast errors related to ticket scanning.
  * Called `_listenBroadcastError` in the `initState` method to initialize the error listener when the `TicketDetailsController` is initialized.