### PR TITLE
Hide unused buttons

### DIFF
--- a/lib/pages/home/home.dart
+++ b/lib/pages/home/home.dart
@@ -743,6 +743,10 @@ class HomeController extends State<HomePage>
     loggy.info('handleGetCurrentLocationSuccess(): success');
     if (success is GetCurrentLocationSuccess) {
       currentLocationNotifier.value = success;
+      mapController.move(
+        convertLocationDataToLatLng(success.currentLocation),
+        HomeViewStyles.initialZoom,
+      );
     } else {
       currentLocationNotifier.value = const GetCurrentLocationIsEmpty();
     }

--- a/lib/pages/home/home_view.dart
+++ b/lib/pages/home/home_view.dart
@@ -4,7 +4,6 @@ import 'package:ecoparking_flutter/domain/state/markers/find_nearby_parkings_sta
 import 'package:ecoparking_flutter/domain/state/markers/get_current_location_state.dart';
 import 'package:ecoparking_flutter/pages/home/home.dart';
 import 'package:ecoparking_flutter/pages/home/home_view_styles.dart';
-import 'package:ecoparking_flutter/pages/home/widgets/rounded_button/rounded_button.dart';
 import 'package:ecoparking_flutter/pages/home/widgets/search_parking/search_parking_anchor.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
@@ -82,11 +81,11 @@ class HomePageView extends StatelessWidget {
                       controller: controller,
                       searchController: controller.searchController,
                     ),
-                    const SizedBox(width: HomeViewStyles.topButtonSpacing),
-                    RoundedButton(
-                      icon: Icons.notifications_none_rounded,
-                      onPressed: controller.onNotificationPressed,
-                    ),
+                    // const SizedBox(width: HomeViewStyles.topButtonSpacing),
+                    // RoundedButton(
+                    //   icon: Icons.notifications_none_rounded,
+                    //   onPressed: controller.onNotificationPressed,
+                    // ),
                   ],
                 ),
               ),

--- a/lib/pages/profile/profile.dart
+++ b/lib/pages/profile/profile.dart
@@ -94,17 +94,17 @@ class ProfileController extends State<ProfilePage>
         leftIcon: Icons.person_outline_rounded,
         onTap: _onEditProfile,
       ),
-      SettingButtonArguments(
-        title: 'Notification',
-        leftIcon: Icons.notifications_outlined,
-        onTap: () {
-          loggy.info('Notification');
-          NavigationUtils.navigateTo(
-            context: context,
-            path: AppPaths.testPage,
-          );
-        },
-      ),
+      // SettingButtonArguments(
+      //   title: 'Notification',
+      //   leftIcon: Icons.notifications_outlined,
+      //   onTap: () {
+      //     loggy.info('Notification');
+      //     NavigationUtils.navigateTo(
+      //       context: context,
+      //       path: AppPaths.testPage,
+      //     );
+      //   },
+      // ),
       SettingButtonArguments(
         title: 'Logout',
         leftIcon: Icons.logout,


### PR DESCRIPTION
## Ticket
- Some buttons has not implemented yet so need to hide it!
## Summary
This pull request includes several changes to the `lib/pages/home` and `lib/pages/profile` directories, focusing on updating the `HomeController` and `ProfileController` classes, as well as removing unused imports and commented-out code.

### Updates to `HomeController`:

* [`lib/pages/home/home.dart`](diffhunk://#diff-c8ae0af0be3a180911b1561a7e0fb0bd68bec2f2b95f9f9d8533fb017c583f3aR746-R749): Added functionality to move the map to the current location when it is successfully retrieved.

### Code cleanup:

* [`lib/pages/home/home_view.dart`](diffhunk://#diff-61674ea203db533a085c33d7fdb1496898f2b527494bb901299dc8fe2c82fce0L7): Removed the import for `rounded_button.dart` as it is no longer used.
* [`lib/pages/home/home_view.dart`](diffhunk://#diff-61674ea203db533a085c33d7fdb1496898f2b527494bb901299dc8fe2c82fce0L85-R88): Commented out the code related to the `RoundedButton` for notifications in the `HomePageView` class.
* [`lib/pages/profile/profile.dart`](diffhunk://#diff-54e4d91bba32cfefb0de79da3d9f87e2d1e610f947acabacd285ca4feab86854L97-R107): Commented out the `SettingButtonArguments` for notifications in the `ProfileController` class.