### PR TITLE
Bump version to v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
+## v0.1.5 - 30/12/2024
+### Updated
+- Hide unused buttons
+- Move map screen when press focus current location
+
 ## v0.1.4 - 22/12/2024
-## Updated
+### Updated
 - README
 
 ## v0.1.3 - 22/12/2024

--- a/lib/pages/home/home.dart
+++ b/lib/pages/home/home.dart
@@ -743,6 +743,10 @@ class HomeController extends State<HomePage>
     loggy.info('handleGetCurrentLocationSuccess(): success');
     if (success is GetCurrentLocationSuccess) {
       currentLocationNotifier.value = success;
+      mapController.move(
+        convertLocationDataToLatLng(success.currentLocation),
+        HomeViewStyles.initialZoom,
+      );
     } else {
       currentLocationNotifier.value = const GetCurrentLocationIsEmpty();
     }

--- a/lib/pages/home/home_view.dart
+++ b/lib/pages/home/home_view.dart
@@ -4,7 +4,6 @@ import 'package:ecoparking_flutter/domain/state/markers/find_nearby_parkings_sta
 import 'package:ecoparking_flutter/domain/state/markers/get_current_location_state.dart';
 import 'package:ecoparking_flutter/pages/home/home.dart';
 import 'package:ecoparking_flutter/pages/home/home_view_styles.dart';
-import 'package:ecoparking_flutter/pages/home/widgets/rounded_button/rounded_button.dart';
 import 'package:ecoparking_flutter/pages/home/widgets/search_parking/search_parking_anchor.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
@@ -82,11 +81,11 @@ class HomePageView extends StatelessWidget {
                       controller: controller,
                       searchController: controller.searchController,
                     ),
-                    const SizedBox(width: HomeViewStyles.topButtonSpacing),
-                    RoundedButton(
-                      icon: Icons.notifications_none_rounded,
-                      onPressed: controller.onNotificationPressed,
-                    ),
+                    // const SizedBox(width: HomeViewStyles.topButtonSpacing),
+                    // RoundedButton(
+                    //   icon: Icons.notifications_none_rounded,
+                    //   onPressed: controller.onNotificationPressed,
+                    // ),
                   ],
                 ),
               ),

--- a/lib/pages/profile/profile.dart
+++ b/lib/pages/profile/profile.dart
@@ -94,17 +94,17 @@ class ProfileController extends State<ProfilePage>
         leftIcon: Icons.person_outline_rounded,
         onTap: _onEditProfile,
       ),
-      SettingButtonArguments(
-        title: 'Notification',
-        leftIcon: Icons.notifications_outlined,
-        onTap: () {
-          loggy.info('Notification');
-          NavigationUtils.navigateTo(
-            context: context,
-            path: AppPaths.testPage,
-          );
-        },
-      ),
+      // SettingButtonArguments(
+      //   title: 'Notification',
+      //   leftIcon: Icons.notifications_outlined,
+      //   onTap: () {
+      //     loggy.info('Notification');
+      //     NavigationUtils.navigateTo(
+      //       context: context,
+      //       path: AppPaths.testPage,
+      //     );
+      //   },
+      // ),
       SettingButtonArguments(
         title: 'Logout',
         leftIcon: Icons.logout,


### PR DESCRIPTION
## Summary
This pull request includes updates to the `CHANGELOG.md` file, changes to the home screen functionality, and the removal of unused buttons in the home and profile pages. The most important changes include updating the changelog, moving the map screen to the current location, and hiding unused buttons.

Updates to changelog:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R7): Added a new version entry for v0.1.5, which includes hiding unused buttons and moving the map screen when pressing the focus current location button.

Home screen functionality:

* [`lib/pages/home/home.dart`](diffhunk://#diff-c8ae0af0be3a180911b1561a7e0fb0bd68bec2f2b95f9f9d8533fb017c583f3aR746-R749): Updated the `HomeController` to move the map to the current location when the location is successfully obtained.

Removal of unused buttons:

* [`lib/pages/home/home_view.dart`](diffhunk://#diff-61674ea203db533a085c33d7fdb1496898f2b527494bb901299dc8fe2c82fce0L7): Removed the import of the `rounded_button.dart` file, which is no longer needed.
* [`lib/pages/home/home_view.dart`](diffhunk://#diff-61674ea203db533a085c33d7fdb1496898f2b527494bb901299dc8fe2c82fce0L85-R88): Commented out the `RoundedButton` widget for notifications in the `HomePageView` class.
* [`lib/pages/profile/profile.dart`](diffhunk://#diff-54e4d91bba32cfefb0de79da3d9f87e2d1e610f947acabacd285ca4feab86854L97-R107): Commented out the `SettingButtonArguments` for notifications in the `ProfileController` class.