### PR TITLE
EF-99: Fix cancel ticket

### DIFF
--- a/lib/pages/book_parking_details/book_parking_details_view.dart
+++ b/lib/pages/book_parking_details/book_parking_details_view.dart
@@ -1,5 +1,6 @@
 import 'package:ecoparking_flutter/config/app_paths.dart';
 import 'package:ecoparking_flutter/pages/book_parking_details/book_parking_details.dart';
+import 'package:ecoparking_flutter/pages/book_parking_details/book_parking_details_view_styles.dart';
 import 'package:ecoparking_flutter/pages/book_parking_details/widgets/daily_view.dart';
 import 'package:ecoparking_flutter/pages/book_parking_details/widgets/hourly_view.dart';
 import 'package:ecoparking_flutter/widgets/app_scaffold.dart';
@@ -23,26 +24,21 @@ class BookParkingDetailsView extends StatelessWidget {
       onBackButtonPressed: controller.onBackButtonPressed,
       body: Scaffold(
         appBar: GFAppBar(
-          bottomOpacity: 0.0,
-          elevation: 0.0,
+          bottomOpacity: BookParkingDetailsViewStyles.bottomOpacity,
+          elevation: BookParkingDetailsViewStyles.elevation,
           backgroundColor: Colors.white,
           title: GFSegmentTabs(
-            width: MediaQuery.of(context).size.width - 150,
+            width: BookParkingDetailsViewStyles.segmentTabsWidth(context),
             length: controller.tabLength,
             tabBarColor: Colors.transparent,
             labelColor: Colors.white,
             unselectedLabelColor: Colors.black,
-            border: Border.all(
-              color: Theme.of(context).colorScheme.primary,
-              width: 1,
-            ),
+            border: BookParkingDetailsViewStyles.segmentTabsBorder(context),
             indicatorPadding: EdgeInsets.zero,
-            borderRadius: const BorderRadius.all(Radius.circular(5)),
+            borderRadius: BookParkingDetailsViewStyles.segmentTabsBorderRadius,
             indicatorSize: TabBarIndicatorSize.tab,
-            indicator: BoxDecoration(
-              color: Theme.of(context).colorScheme.primary,
-              borderRadius: const BorderRadius.all(Radius.circular(5)),
-            ),
+            indicator:
+                BookParkingDetailsViewStyles.segmentTabsIndicator(context),
             tabs: const <Widget>[
               Tab(child: Text('Theo giờ')),
               Tab(child: Text('Theo ngày')),

--- a/lib/pages/book_parking_details/book_parking_details_view_styles.dart
+++ b/lib/pages/book_parking_details/book_parking_details_view_styles.dart
@@ -3,6 +3,11 @@ import 'package:flutter/material.dart';
 class BookParkingDetailsViewStyles {
   static const double spacing = 16.0;
   static const double wrapperSpacing = 8.0;
+  static const double bottomOpacity = 0.0;
+  static const double elevation = 0.0;
+
+  static double segmentTabsWidth(BuildContext context) =>
+      MediaQuery.of(context).size.width - 150;
 
   static const EdgeInsetsGeometry bottomContainerPadding = EdgeInsets.only(
     top: 8.0,
@@ -42,5 +47,19 @@ class BookParkingDetailsViewStyles {
           topRight: Radius.circular(20),
         ),
         color: Colors.white,
+      );
+
+  static Border segmentTabsBorder(BuildContext context) => Border.all(
+        color: Theme.of(context).colorScheme.primary,
+        width: 1,
+      );
+
+  static const BorderRadius segmentTabsBorderRadius =
+      BorderRadius.all(Radius.circular(5));
+
+  static BoxDecoration segmentTabsIndicator(BuildContext context) =>
+      BoxDecoration(
+        color: Theme.of(context).colorScheme.primary,
+        borderRadius: const BorderRadius.all(Radius.circular(5)),
       );
 }

--- a/lib/pages/my_tickets/my_tickets.dart
+++ b/lib/pages/my_tickets/my_tickets.dart
@@ -219,15 +219,8 @@ class MyTicketsController extends State<MyTicketsPage>
     _getTicketsForPage(currentPage);
   }
 
-  void cancelBooking() {
-    loggy.info('cancelBooking()');
-
-    final ticketId = _bookingService.selectedTicketId;
-
-    if (ticketId == null) {
-      loggy.error('Ticket id is null');
-      return;
-    }
+  void cancelBooking(Ticket ticket) {
+    final ticketId = ticket.id;
 
     _cancelTicketSubscription =
         _cancelTicketInteractor.execute(ticketId).listen(

--- a/lib/pages/my_tickets/widgets/list_ticket.dart
+++ b/lib/pages/my_tickets/widgets/list_ticket.dart
@@ -7,7 +7,7 @@ import 'package:flutter/material.dart';
 class ListTicket extends StatelessWidget {
   final ValueNotifier<GetUserTicketsState> ticketsNotifier;
   final TicketPages page;
-  final void Function()? onCancelBooking;
+  final void Function(Ticket)? onCancelBooking;
   final void Function(Ticket)? onViewTicket;
 
   const ListTicket({

--- a/lib/pages/my_tickets/widgets/ticket_card.dart
+++ b/lib/pages/my_tickets/widgets/ticket_card.dart
@@ -9,7 +9,7 @@ import 'package:google_fonts/google_fonts.dart';
 class TicketCard extends StatelessWidget {
   final Ticket ticket;
   final TicketPages page;
-  final void Function()? onCancelBooking;
+  final void Function(Ticket)? onCancelBooking;
   final void Function(Ticket)? onViewTicket;
 
   const TicketCard({
@@ -184,7 +184,7 @@ class TicketCard extends StatelessWidget {
 
   Widget renderButtonsRow(
     TicketPages page, {
-    void Function()? onCancelBooking,
+    void Function(Ticket)? onCancelBooking,
     void Function(Ticket)? onViewTicket,
   }) {
     switch (page) {
@@ -195,7 +195,11 @@ class TicketCard extends StatelessWidget {
               child: ActionButton(
                 type: ActionButtonType.hollow,
                 label: 'Hủy vé',
-                onPressed: onCancelBooking,
+                onPressed: () {
+                  if (onCancelBooking != null) {
+                    onCancelBooking(ticket);
+                  }
+                },
                 height: 36,
                 // padding: const EdgeInsets.symmetric(vertical: 8.0),
               ),


### PR DESCRIPTION
## Ticket
- Closes #99 

## Root cause
- When call cancel ticket, we are using ticket id from booking service which is null at the same time.

## Solution
- Pass ticketId using pressed ticket

## Summary
This pull request includes changes to the ticket cancellation functionality in the `my_tickets` module. The main focus is to pass the `Ticket` object to the cancellation function to provide more context and improve error handling.

Changes to ticket cancellation functionality:

* [`lib/pages/my_tickets/my_tickets.dart`](diffhunk://#diff-4fda72e6b9a807c946a4ba050327ab87ee87999e68a81652f7d909a0858b70afL222-R223): Modified the `cancelBooking` method to accept a `Ticket` object instead of using the selected ticket ID from the booking service.

* [`lib/pages/my_tickets/widgets/list_ticket.dart`](diffhunk://#diff-db391951266be52b0a38b21a2e1c8d2de1118fda04be5eeaa3fab4960a3d9079L10-R10): Updated the `onCancelBooking` callback in the `ListTicket` widget to accept a `Ticket` object.

* `lib/pages/my_tickets/widgets/ticket_card.dart`: 
  * Updated the `onCancelBooking` callback in the `TicketCard` widget to accept a `Ticket` object.
  * Modified the `renderButtonsRow` method to pass the `Ticket` object to the `onCancelBooking` callback.
  * Ensured the `onCancelBooking` callback is called with the `Ticket` object when the cancel button is pressed.

